### PR TITLE
Fix build failure due to flapdoodle-oss/de.flapdoodle.embed.mongo#230

### DIFF
--- a/component/src/test/java/org/ballerinalang/data/mongodb/utils/MongoDBTestUtils.java
+++ b/component/src/test/java/org/ballerinalang/data/mongodb/utils/MongoDBTestUtils.java
@@ -31,7 +31,10 @@ import java.io.IOException;
 public class MongoDBTestUtils {
 
     public static final int MONGODB_PORT = 27017;
-    public static final String MONGODB_HOST = "localhost";
+    // Cannot use "localhost" here due to
+    // https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/230
+    // This issue be fixed once mondodb.version is upgraded to 3.6.2
+    public static final String MONGODB_HOST = "127.0.0.1";
 
     /**
      * This method sets up a MongoDB on localhost without authentication.
@@ -55,8 +58,12 @@ public class MongoDBTestUtils {
      * @param mongoClient
      */
     public static void releaseResources(MongodExecutable mongodExecutable, MongoClient mongoClient) {
-        mongodExecutable.stop();
-        mongoClient.close();
+        if (mongodExecutable != null) {
+            mongodExecutable.stop();
+        }
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
     }
 
 }

--- a/component/src/test/resources/samples/mongodb-actions-test.bal
+++ b/component/src/test/resources/samples/mongodb-actions-test.bal
@@ -1,8 +1,10 @@
 import ballerina.data.mongodb;
 
+const string cassandraHost = "127.0.0.1";
+
 function insert() {
     endpoint<mongodb:ClientConnector> conn {
-                create mongodb:ClientConnector("localhost", "studentdb", "", "", {sslEnabled:false,
+                create mongodb:ClientConnector(cassandraHost, "studentdb", "", "", {sslEnabled:false,
 serverSelectionTimeout:500});
     }
     json document = {"name":"Tom", "age":"20"};
@@ -12,7 +14,7 @@ serverSelectionTimeout:500});
 
 function find() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                    create mongodb:ClientConnector("localhost", "studentdb", "", "", {sslEnabled:false,
+                    create mongodb:ClientConnector(cassandraHost, "studentdb", "", "", {sslEnabled:false,
     serverSelectionTimeout:500});
     }
     json query = {"age":"21"};
@@ -23,7 +25,7 @@ function find() (json) {
 
 function findWithNullQuery() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                    create mongodb:ClientConnector("localhost", "studentdb", "", "", {sslEnabled:false,
+                    create mongodb:ClientConnector(cassandraHost, "studentdb", "", "", {sslEnabled:false,
     serverSelectionTimeout:500});
     }
     json query = null;
@@ -34,7 +36,7 @@ function findWithNullQuery() (json) {
 
 function findOne() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                    create mongodb:ClientConnector("localhost", "studentdb", "", "", {sslEnabled:false,
+                    create mongodb:ClientConnector(cassandraHost, "studentdb", "", "", {sslEnabled:false,
     serverSelectionTimeout:500});
     }
     json query = {"name":"Jim", "age":"21"};
@@ -45,7 +47,7 @@ function findOne() (json) {
 
 function findOneWithNullQuery() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                    create mongodb:ClientConnector("localhost", "studentdb", "", "", {sslEnabled:false,
+                    create mongodb:ClientConnector(cassandraHost, "studentdb", "", "", {sslEnabled:false,
     serverSelectionTimeout:500});
     }
     json query = null;
@@ -56,7 +58,7 @@ function findOneWithNullQuery() (json) {
 
 function deleteMultipleRecords() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                        create mongodb:ClientConnector("localhost", "studentdb", "", "",  {sslEnabled:false,
+                        create mongodb:ClientConnector(cassandraHost, "studentdb", "", "",  {sslEnabled:false,
         serverSelectionTimeout:500});
     }
     json filter = {"age":"25"};
@@ -67,7 +69,7 @@ function deleteMultipleRecords() (json) {
 
 function deleteSingleRecord() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                        create mongodb:ClientConnector("localhost", "studentdb", "", "",  {sslEnabled:false,
+                        create mongodb:ClientConnector(cassandraHost, "studentdb", "", "",  {sslEnabled:false,
         serverSelectionTimeout:500});
     }
     json filter = {"age":"13"};
@@ -78,7 +80,7 @@ function deleteSingleRecord() (json) {
 
 function updateMultipleRecords() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                            create mongodb:ClientConnector("localhost", "studentdb", "", "",  {sslEnabled:false,
+                            create mongodb:ClientConnector(cassandraHost, "studentdb", "", "",  {sslEnabled:false,
             serverSelectionTimeout:500});
     }
     json filter = {"age":"28"};
@@ -90,7 +92,7 @@ function updateMultipleRecords() (json) {
 
 function updateSingleRecord() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                            create mongodb:ClientConnector("localhost", "studentdb",  "", "", {sslEnabled:false,
+                            create mongodb:ClientConnector(cassandraHost, "studentdb",  "", "", {sslEnabled:false,
             serverSelectionTimeout:500});
     }
     json filter = {"age":"30"};
@@ -102,7 +104,7 @@ function updateSingleRecord() (json) {
 
 function batchInsert() {
     endpoint<mongodb:ClientConnector> conn {
-                                create mongodb:ClientConnector("localhost", "studentdb",  "", "", {sslEnabled:false,
+                                create mongodb:ClientConnector(cassandraHost, "studentdb",  "", "", {sslEnabled:false,
                 serverSelectionTimeout:500});
     }
     json docs = [{name:"Jessie",age:"18"}, {name:"Rose",age:"17"}, {name:"Anne",age:"15"}];

--- a/component/src/test/resources/samples/mongodb-connection-test.bal
+++ b/component/src/test/resources/samples/mongodb-connection-test.bal
@@ -1,9 +1,11 @@
 import ballerina.data.mongodb;
 
+const string cassandraHost = "127.0.0.1";
+
 function testConnectorInitWithDirectUrl() (json) {
     endpoint<mongodb:ClientConnector> conn {
                     create mongodb:ClientConnector("", "studentdb",  "", "", {url:
-                    "mongodb://localhost:27017/?sslEnabled=false&serverSelectionTimeout=500"});
+                    "mongodb://" + cassandraHost + ":27017/?sslEnabled=false&serverSelectionTimeout=500"});
         }
     json query = {"name":"Jim", "age":"21"};
     json result = conn.find("students", query);
@@ -13,7 +15,7 @@ function testConnectorInitWithDirectUrl() (json) {
 
 function testConnectorInitWithConnectionPoolProperties() (json) {
     endpoint<mongodb:ClientConnector> conn {
-                    create mongodb:ClientConnector("localhost", "studentdb",  "", "", {sslEnabled: false,
+                    create mongodb:ClientConnector(cassandraHost, "studentdb",  "", "", {sslEnabled: false,
                     serverSelectionTimeout: 500, maxPoolSize: 1, maxIdleTime: 60000, maxLifeTime: 1800000,
                     minPoolSize: 1, waitQueueMultiple: 1, waitQueueTimeout: 150 });
         }
@@ -25,7 +27,7 @@ function testConnectorInitWithConnectionPoolProperties() (json) {
 
 function testConnectorInitWithInvalidAuthMechanism() {
     endpoint<mongodb:ClientConnector> conn {
-                    create mongodb:ClientConnector("localhost", "studentdb",  "", "", {sslEnabled: false,
+                    create mongodb:ClientConnector(cassandraHost, "studentdb",  "", "", {sslEnabled: false,
                     serverSelectionTimeout: 500, authMechanism: "invalid-auth-mechanism" });
         }
 }


### PR DESCRIPTION
## Purpose
Fixing build failure due to [2]. Here using "localhost" to start the embeded mongoDB caused build failure in docker container created by the image at [1]. According to the information at [2] this will be fixed in MongoDB 3.6.2. Until then have to use a work around if we are to use "localhost"

[1] https://github.com/wso2/build-automation-artifacts/blob/master/docker/Dockerfile
[2] flapdoodle-oss/de.flapdoodle.embed.mongo#230

## Approach
Use "127.0.0.1" instead of "localhost" until the issue is fixed in MongoDB.

